### PR TITLE
Install clazy, this enables us to run the clang based Qt code checker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -y && \
     locales \
     build-essential \
     clang \
+    clazy \
     ninja-build \
     cmake \
     extra-cmake-modules \


### PR DESCRIPTION
@tboerger  @dschmidt