### PR TITLE
Ensure we find the qtlinguist

### DIFF
--- a/clang/Dockerfile.amd64
+++ b/clang/Dockerfile.amd64
@@ -21,6 +21,7 @@ RUN apt-get update -y && \
       libcmocka-dev \
       qt5-default \
       qttools5-dev-tools \
+      qttools5-dev \
       qt5keychain-dev \
       kio-dev && \
     apt-get clean && \


### PR DESCRIPTION
https://stackoverflow.com/questions/51698075/cmake-cannot-find-qt5linguisttools-in-docker-ubuntu-18-04