### PR TITLE
Build image with Qt6

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -82,7 +82,7 @@ RUN git clone https://github.com/owncloud/libre-graph-api-cpp-qt-client && \
     cd libre-graph-api-cpp-qt-client/client && \
     mkdir build && \
     cd build && \
-    cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -G Ninja && \
+    cmake .. -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -G Ninja && \
     ninja install -v && \
     cd ../../.. && \
     rm -r libre-graph-api-cpp-qt-client && \

--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -58,10 +58,10 @@ RUN yum install -y \
     libsqlite3x-devel \
     openssl-devel \
     libcmocka-devel \
-    qt5-qtbase-devel \
-    qt5-qttools-devel \
+    qt6-qtbase-devel \
+    qt6-qttools-devel \
+    qtkeychain-qt6-devel \
     libcloudproviders-devel \
-    qtkeychain-qt5-devel \
     kf5-kio-devel \
     && yum autoremove -y \
     && yum clean all

--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -66,11 +66,13 @@ RUN yum install -y \
     && yum autoremove -y \
     && yum clean all
 
+ENV CMAKE_PREFIX_PATH=/usr/lib64/cmake/Qt6
+
 RUN git clone https://github.com/kdab/kdsingleapplication && \
     cd kdsingleapplication && \
     mkdir build && \
     cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -G Ninja && \
+    cmake .. -DKDSingleApplication_QT6=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -G Ninja && \
     ninja install -v && \
     cd ../.. && \
     rm -r kdsingleapplication && \
@@ -80,7 +82,7 @@ RUN git clone https://github.com/owncloud/libre-graph-api-cpp-qt-client && \
     cd libre-graph-api-cpp-qt-client/client && \
     mkdir build && \
     cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -G Ninja && \
+    cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -G Ninja && \
     ninja install -v && \
     cd ../../.. && \
     rm -r libre-graph-api-cpp-qt-client && \


### PR DESCRIPTION
With this PR, the image will have QT6 (`6.5.1`) required for the desktop client version 5.0