### PR TITLE
Use Qt version 6.4.3

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -58,8 +58,8 @@ RUN yum install -y \
     libsqlite3x-devel \
     openssl-devel \
     libcmocka-devel \
-    qt6-qtbase-devel \
-    qt6-qttools-devel \
+    qt6-qtbase-devel-6.4.3 \
+    qt6-qttools-devel-6.4.3 \
     qtkeychain-qt6-devel \
     libcloudproviders-devel \
     kf5-kio-devel \


### PR DESCRIPTION
Install Qt version 6.4.3 to build the desktop-client with it. We are using Squish7.1-Qt6.4, so it is required to build client with Qt6.4 version for GUI tests to be able to automate the client.