### PR TITLE
chore: bump qt to 6.8.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -10,7 +10,7 @@ def main(ctx):
 
   # image's base version
   base_img_tag = {
-    'fedora': ['fedora', '39'],
+    'fedora': ['fedora', '41'],
   }
 
   config = {

--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:41
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
     org.label-schema.name="ownCloud Client" \
@@ -62,9 +62,9 @@ RUN yum install -y \
     libsqlite3x-devel \
     openssl-devel \
     libcmocka-devel \
-    qt6-qtbase-devel-6.6.2 \
-    qt6-qtdeclarative-devel-6.6.2 \
-    qt6-qttools-devel-6.6.2 \
+    qt6-qtbase-devel-6.8.0 \
+    qt6-qtdeclarative-devel-6.8.0 \
+    qt6-qttools-devel-6.8.0 \
     qtkeychain-qt6-devel \
     kf5-kio-devel \
     && yum autoremove -y \


### PR DESCRIPTION
Updated Qt version to `6.8.0` using fedora `41`